### PR TITLE
Bump JMS serializer version to 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.4",
         "simple-bus/serialization": ">=1.0",
-        "jms/serializer": "~0.12"
+        "jms/serializer": "~0.12||~1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
As JMS Serializer version 1 is out, it should be good to upgrade the dependency.
